### PR TITLE
fix occasional errors we see when generating a uuid using uuid library by switching to securerandom

### DIFF
--- a/emailage.gemspec
+++ b/emailage.gemspec
@@ -26,6 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "redcarpet", "~> 3.3"
 
   spec.add_dependency "typhoeus", "~> 1.0"
-  spec.add_dependency "uuid", "~> 2.3"
   spec.add_dependency "json", "~> 2.3"
 end

--- a/lib/emailage/client.rb
+++ b/lib/emailage/client.rb
@@ -1,5 +1,5 @@
 require 'typhoeus'
-require 'uuid'
+require 'securerandom'
 require 'json'
 
 module Emailage
@@ -38,7 +38,7 @@ module Emailage
       params = {
         :format => 'json', 
         :oauth_consumer_key => @secret,
-        :oauth_nonce => UUID.new.generate,
+        :oauth_nonce => SecureRandom.uuid,
         :oauth_signature_method => 'HMAC-SHA1',
         :oauth_timestamp => Time.now.to_i,
         :oauth_version => 1.0


### PR DESCRIPTION
example of the error we were seeing in prod:
```
NoMethodError: undefined method `unpack' for nil:NilClass
/usr/local/bundle/ruby/2.7.0/gems/uuid-2.3.9/lib/uuid.rb:377:in `read_state': undefined method `unpack' for nil:NilClass (NoMethodError)
	
from /usr/local/bundle/ruby/2.7.0/gems/uuid-2.3.9/lib/uuid.rb:333:in `block in next_sequence'
	
from /usr/local/bundle/ruby/2.7.0/gems/uuid-2.3.9/lib/uuid.rb:367:in `block in open_lock'
	
from /usr/local/bundle/ruby/2.7.0/gems/uuid-2.3.9/lib/uuid.rb:364:in `open'
	
from /usr/local/bundle/ruby/2.7.0/gems/uuid-2.3.9/lib/uuid.rb:364:in `open_lock'
	
from /usr/local/bundle/ruby/2.7.0/gems/uuid-2.3.9/lib/uuid.rb:332:in `next_sequence'
	
from /usr/local/bundle/ruby/2.7.0/gems/uuid-2.3.9/lib/uuid.rb:263:in `initialize'
	
from /usr/local/bundle/ruby/2.7.0/gems/emailage-1.1.0/lib/emailage/client.rb:41:in `new'
	
from /usr/local/bundle/ruby/2.7.0/gems/emailage-1.1.0/lib/emailage/client.rb:41:in `request'
	
from /usr/local/bundle/ruby/2.7.0/gems/emailage-1.1.0/lib/emailage/client.rb:65:in `query'
	
from /app/lib/emailage_verification/client.rb:10:in `query'
```

maintainers of uuid gem did not address this so people switched to SecureRandom: https://github.com/assaf/uuid/issues/28
